### PR TITLE
Fix use cases enlarge screenshot issue

### DIFF
--- a/_includes/usecases.html
+++ b/_includes/usecases.html
@@ -37,7 +37,7 @@
         class="bg-gray-800 p-8 max-w-6xl rounded-lg shadow-lg flex flex-col justify-center"
       >
         <a
-          class="screenshot-url"
+          class="screenshot-url use-case-screenshot"
           href="assets/{{site.data.use_cases[page.title][0].image}}"
           target="_blank"
         >
@@ -104,8 +104,10 @@
       "assets/" + image,
       document.querySelector(".screenshot-image")
     );
-    document.querySelector(".screenshot-image").src = "assets/" + image;
-    document.querySelector(".screenshot-url").href = "assets/" + image;
+    var useCaseScreenshotElement = document.querySelector(".use-case-screenshot.screenshot-url");
+    var useCaseImageUrl = "assets/" + image;
+    useCaseScreenshotElement.href = useCaseImageUrl;
+    useCaseScreenshotElement.querySelector(".screenshot-image").src = useCaseImageUrl;
 
     var button = event.target.closest("button");
     var buttons = document.querySelectorAll(".use-case-button");


### PR DESCRIPTION
When you click on the "Click to enlarge" button, you will always see the default image. This happens because there are two `.screenshot-url` elements in the home page, but the code only selects the first one (which is not in the "Use Cases" section.). This commit fixes this issue.

#### Current Behavior

https://user-images.githubusercontent.com/1054228/224065829-e32d37a2-293c-4e8f-adb1-a055efa8db28.mp4

#### Expected Behavior

https://user-images.githubusercontent.com/1054228/224065871-feab8dd2-5ba0-4492-b485-d9ed9874b1df.mp4

