### PR TITLE
Fix 404 for GitHub Sponsors

### DIFF
--- a/sponsor.md
+++ b/sponsor.md
@@ -11,7 +11,7 @@ Sponsor Mathesar
 {% capture subheader %}
 Mathesar is a non-profit project maintained by a small team. Your financial support helps us sustain the project.
 
-You can sponsor Mathesar through [Open Collective](https://opencollective.com/mathesar){:target="_blank" rel="noopener"} or [GitHub Sponsors](https://github.com/sponsors/centerofci/dashboard/profile){:target="_blank" rel="noopener"}.
+You can sponsor Mathesar through [Open Collective](https://opencollective.com/mathesar){:target="_blank" rel="noopener"} or [GitHub Sponsors](https://github.com/sponsors/centerofci){:target="_blank" rel="noopener"}.
 
 {% endcapture %}
 


### PR DESCRIPTION
Existing URL may only work for project admins, doesn't work for me in any case.